### PR TITLE
Alternate mobile

### DIFF
--- a/layouts/cover/single.html
+++ b/layouts/cover/single.html
@@ -2,7 +2,7 @@
 
 THIS CUSTOM OVERRIDE VERSION OF THE COVER TEMPLATE ADDS A CSS-ANIMATED
 SLIDESHOW, LINE 24, THAT AUTOMATICALLY ROTATES EVERY 2 SECONDS. THERE
-ARE ALSO LABELS FOR EACH IMAGE. 
+ARE ALSO LABELS FOR EACH IMAGE.
 
 BASE CODE CAME FROM: http://css3.bradshawenterprises.com/cfimg/
 
@@ -30,12 +30,12 @@ Cover page layout. This controls the home page of the publication.
   {{/* Begin full-page cover section */}}
   {{- if .Params.slides -}}
     <section class="quire-cover__hero hero is-fullheight">
-      
-      <div class="quire-cover__overlay upper-left">        
+
+      <div class="quire-cover__overlay upper-left">
         {{- range .Params.slides -}}
         {{- $imgPath := printf "%s/%s/%s" ($.Scratch.Get "imageDir") "upper-left" .image -}}
         <img src="{{ $imgPath | relURL }}" />
-        {{- end -}}      
+        {{- end -}}
       </div>
       <div class="quire-cover__overlay upper-right">
         {{- range .Params.slides -}}
@@ -55,11 +55,11 @@ Cover page layout. This controls the home page of the publication.
         <img src="{{ $imgPath | relURL }}" />
         {{- end -}}
       </div>
-      
-      
-      
-      
-      
+
+
+
+
+
 
   {{- else -}}
     <section class="quire-cover__hero hero is-fullheight">
@@ -69,7 +69,7 @@ Cover page layout. This controls the home page of the publication.
       <div class="container is-fluid">
         {{/* Use .Site.Data.publication info if available */}}
         {{ if .Site.Data.publication }}
-        
+
         {{- $endPunctuation := findRE "[!|?]$" .Site.Data.publication.title -}}
         <h1 class="title">
           {{ .Site.Data.publication.title | markdownify }}
@@ -88,7 +88,7 @@ Cover page layout. This controls the home page of the publication.
         {{ .Site.Data.publication.contributor_as_it_appears | markdownify }}
         {{ else }}
         <span class="visually-hidden">Contributors: </span>
-        
+
           {{/* List primary contributors unless none are marked as primary
                in which case list all contributors in publication.yml */}}
           {{/* ------------------------------------------------------------ */}}
@@ -101,7 +101,7 @@ Cover page layout. This controls the home page of the publication.
             <em>{{ partial "contributor-list.html" (dict "range" .Site.Data.publication.contributor "contributorType" "primary" "listType" "string" "Site" $.Site) }}</em>
           {{- else -}}
             <em>{{ partial "contributor-list.html" (dict "range" .Site.Data.publication.contributor "contributorType" "all" "listType" "string" "Site" $.Site) }}</em>
-          {{- end -}}        
+          {{- end -}}
         {{- end -}}
         </div>
 
@@ -112,7 +112,7 @@ Cover page layout. This controls the home page of the publication.
       </div>
     </div>
   </section>
-    
+
   <section class="quire-cover__more" >
     <div class="quire-cover__more-body hero-more">
       {{ if and (ne $.Site.Params.epub true) (ne $.Site.Params.pdf true) }}
@@ -129,6 +129,27 @@ Cover page layout. This controls the home page of the publication.
   <section class="section quire-page__content" id="content">
     <div class="container is-fluid">
       <div class="content">
+        <div class="mobile-contributor">
+        {{- if .Site.Data.publication.contributor_as_it_appears -}}
+        {{ .Site.Data.publication.contributor_as_it_appears | markdownify }}
+        {{ else }}
+        <span class="visually-hidden">Contributors: </span>
+
+          {{/* List primary contributors unless none are marked as primary
+               in which case list all contributors in publication.yml */}}
+          {{/* ------------------------------------------------------------ */}}
+          {{- range .Site.Data.publication.contributor -}}
+            {{- if .type -}}
+              {{ $.Scratch.Set "type" true }}
+            {{- end -}}
+          {{- end -}}
+          {{ if eq ($.Scratch.Get "type") true }}
+            <em>{{ partial "contributor-list.html" (dict "range" .Site.Data.publication.contributor "contributorType" "primary" "listType" "string" "Site" $.Site) }}</em>
+          {{- else -}}
+            <em>{{ partial "contributor-list.html" (dict "range" .Site.Data.publication.contributor "contributorType" "all" "listType" "string" "Site" $.Site) }}</em>
+          {{- end -}}
+        {{- end -}}
+        </div>
         {{ .Content }}
         {{ partial "page-bibliography.html" . }}
       </div>
@@ -139,7 +160,7 @@ Cover page layout. This controls the home page of the publication.
 
   {{/* End "below-the-fold" section */}}
   {{ partial "footer-buttons.html" . }}
-  
+
   {{ if eq $.Site.Params.pdf true }}
     {{ partial "pdf-title-pages.html" (dict "site" .Site) }}
   {{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -205,12 +205,32 @@
   margin-top: 1.5rem;
 }
 
+/* add contributors to cover content area for mobile devices only */
+.mobile-contributor {
+  display: none;
+  text-align: center;
+  margin-bottom: 1rem;
+  font-weight: bold;
+}
+
+/* Soften black on down arrow circle */
+.quire-cover__more .hero-more {
+  background: #333;
+}
+
 @media screen and (max-width: 689px){
   .quire-cover__hero {
     overflow: hidden;
   }
   .quire-cover__overlay {
     width: 100%;
+    /* make the top images 40% height */
+    height: calc((95vh - 3rem) * .4);
+    min-height: calc((95vh - 3rem) * .4);
+  }
+  .quire-cover__overlay img {
+    /* show more of the image */
+    object-fit: cover;
   }
   .quire-cover__overlay.upper-left,
   .quire-cover__overlay.lower-left {
@@ -220,8 +240,33 @@
   .quire-cover__overlay.lower-right {
     margin-right: -50%;
   }
+  .quire-cover__overlay.lower-left,
+  .quire-cover__overlay.lower-right {
+    top: 40%;
+    /* make the bottom images 60% height */
+    height: calc((95vh - 3rem) * .6);
+    min-height: calc((95vh - 3rem) * .6);
+  }
+  /* aadjust spacing and display on title/subtitle block */
   .hero-body .container.is-fluid {
     bottom: 0%;
+    margin: 0;
+    padding-bottom: 40px;
+    text-align: center;
+  }
+  .quire-cover__hero .title {
+    margin: 0;
+  }
+  .quire-cover__hero .subtitle {
+    line-height: 1.35;
+  }
+  /* hide contributor in title block */
+  .quire-cover__hero .contributor {
+    display: none;
+  }
+  /* display contributor in content area */
+  .mobile-contributor {
+    display: block;
   }
 }
 


### PR DESCRIPTION
@mandrijauskas I reverted your last commit and tried a different approach with the mobile screen. Rather than move the whole title block down below the image, I zoomed out on the image to show more of it, and I moved just the contributors down. What do you think?